### PR TITLE
Pulling in Dougbu's changes: Mock `HttpContext`, not `DefaultHttpContext`

### DIFF
--- a/test/Microsoft.AspNet.Mvc.Core.Test/ControllerBaseTest.cs
+++ b/test/Microsoft.AspNet.Mvc.Core.Test/ControllerBaseTest.cs
@@ -448,7 +448,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
         public void Created_IDisposableObject_RegistersForDispose()
         {
             // Arrange
-            var mockHttpContext = new Mock<DefaultHttpContext>();
+            var mockHttpContext = new Mock<HttpContext>();
             mockHttpContext.Setup(x => x.Response.RegisterForDispose(It.IsAny<IDisposable>()));
             var uri = new Uri("/test/url", UriKind.Relative);
 
@@ -534,7 +534,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
         public void CreatedAtAction_IDisposableObject_RegistersForDispose()
         {
             // Arrange
-            var mockHttpContext = new Mock<DefaultHttpContext>();
+            var mockHttpContext = new Mock<HttpContext>();
             mockHttpContext.Setup(x => x.Response.RegisterForDispose(It.IsAny<IDisposable>()));
 
             var controller = new TestableController();
@@ -616,7 +616,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
         public void CreatedAtRoute_IDisposableObject_RegistersForDispose()
         {
             // Arrange
-            var mockHttpContext = new Mock<DefaultHttpContext>();
+            var mockHttpContext = new Mock<HttpContext>();
             mockHttpContext.Setup(x => x.Response.RegisterForDispose(It.IsAny<IDisposable>()));
 
             var controller = new TestableController();
@@ -709,7 +709,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
         public void File_WithStream()
         {
             // Arrange
-            var mockHttpContext = new Mock<DefaultHttpContext>();
+            var mockHttpContext = new Mock<HttpContext>();
             mockHttpContext.Setup(x => x.Response.RegisterForDispose(It.IsAny<IDisposable>()));
 
             var controller = new TestableController();
@@ -731,7 +731,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
         public void File_WithStreamAndFileDownloadName()
         {
             // Arrange
-            var mockHttpContext = new Mock<DefaultHttpContext>();
+            var mockHttpContext = new Mock<HttpContext>();
             mockHttpContext.Setup(x => x.Response.RegisterForDispose(It.IsAny<IDisposable>()));
 
             var controller = new TestableController();
@@ -799,7 +799,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
         public void HttpNotFound_IDisposableObject_RegistersForDispose()
         {
             // Arrange
-            var mockHttpContext = new Mock<DefaultHttpContext>();
+            var mockHttpContext = new Mock<HttpContext>();
             mockHttpContext.Setup(x => x.Response.RegisterForDispose(It.IsAny<IDisposable>()));
 
             var controller = new TestableController();
@@ -837,7 +837,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
         public void Ok_WithIDisposableObject_RegistersForDispose()
         {
             // Arrange
-            var mockHttpContext = new Mock<DefaultHttpContext>();
+            var mockHttpContext = new Mock<HttpContext>();
             mockHttpContext.Setup(x => x.Response.RegisterForDispose(It.IsAny<IDisposable>()));
 
             var controller = new TestableController();
@@ -891,7 +891,7 @@ namespace Microsoft.AspNet.Mvc.Core.Test
         public void BadRequest_IDisposableObject_RegistersForDispose()
         {
             // Arrange
-            var mockHttpContext = new Mock<DefaultHttpContext>();
+            var mockHttpContext = new Mock<HttpContext>();
             mockHttpContext.Setup(x => x.Response.RegisterForDispose(It.IsAny<IDisposable>()));
 
             var controller = new TestableController();

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ControllerTest.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ControllerTest.cs
@@ -3,10 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Internal;
@@ -14,9 +12,6 @@ using Microsoft.AspNet.Mvc.Filters;
 using Microsoft.AspNet.Mvc.ModelBinding;
 using Microsoft.AspNet.Mvc.ModelBinding.Validation;
 using Microsoft.AspNet.Mvc.ViewFeatures;
-using Microsoft.AspNet.Routing;
-using Microsoft.AspNet.Testing;
-using Microsoft.Net.Http.Headers;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
@@ -189,7 +184,7 @@ namespace Microsoft.AspNet.Mvc.Test
         public void Controller_Json_IDisposableObject_RegistersForDispose()
         {
             // Arrange
-            var mockHttpContext = new Mock<DefaultHttpContext>();
+            var mockHttpContext = new Mock<HttpContext>();
             mockHttpContext.Setup(x => x.Response.RegisterForDispose(It.IsAny<IDisposable>()));
 
             var controller = new TestableController();
@@ -212,7 +207,7 @@ namespace Microsoft.AspNet.Mvc.Test
         public void Controller_JsonWithParameterValueAndSerializerSettings_IDisposableObject_RegistersForDispose()
         {
             // Arrange
-            var mockHttpContext = new Mock<DefaultHttpContext>();
+            var mockHttpContext = new Mock<HttpContext>();
             mockHttpContext.Setup(x => x.Response.RegisterForDispose(It.IsAny<IDisposable>()));
 
             var controller = new TestableController();
@@ -262,7 +257,7 @@ namespace Microsoft.AspNet.Mvc.Test
             // Assert
             Assert.True(controller.DisposeCalled);
         }
-        
+
         [Fact]
         public void TempData_CanSetAndGetValues()
         {

--- a/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ControllerUnitTestabilityTests.cs
+++ b/test/Microsoft.AspNet.Mvc.ViewFeatures.Test/ControllerUnitTestabilityTests.cs
@@ -149,7 +149,7 @@ namespace Microsoft.AspNet.Mvc
             var content = "<html>CreatedBody</html>";
             var contentType = "text/html";
             var fileName = "Created.html";
-            var mockHttpContext = new Mock<DefaultHttpContext>();
+            var mockHttpContext = new Mock<HttpContext>();
             mockHttpContext.Setup(x => x.Response.RegisterForDispose(It.IsAny<IDisposable>()));
 
             var controller = new TestabilityController();
@@ -563,7 +563,7 @@ namespace Microsoft.AspNet.Mvc
 
             // Assert
             Assert.NotNull(result);
-            
+
             Assert.Equal("TagCloud", result.ViewComponentName);
         }
 


### PR DESCRIPTION
- build break
- recent HttpAbstractions changes made `DefaultHttpContext` harder to mock (would need `CallBase=true`)
